### PR TITLE
Replace 'prefixed' with 'suffixed' in spec.md

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -88,7 +88,7 @@ every post **must** have one id, which
 ### url
 
 the url of a post **must** contain the id. 
-the url prefixed by `.json` **must** deliver the json of the post.
+the url suffixed by `.json` **must** deliver the json of the post.
 
 ### content_html
 


### PR DESCRIPTION
It seems that `.json` should be added to the URL as a suffix rather than a prefix.